### PR TITLE
chore(devx): add type-check command

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "author": "Matteo Hertel <info@matteohertel.com>",
   "license": "MIT",
   "scripts": {
+    "type-check": "tsc --noEmit",
     "dev": "ts-node ./src"
   },
   "devDependencies": {


### PR DESCRIPTION
### Overview

This PR adds the `type-check` command for a better DevX

When developing or as git hook this command will build the project withouth emitting the compiled files, this is faster than a full build and makes it easier to run it over and over, an example:

```
╰─ yarn type-check
yarn run v1.22.5
$ tsc --noEmit
src/index.ts:5:15 - error TS2554: Expected 0 arguments, but got 1.

5 forgetTheRest("one");
                ~~~~~


Found 1 error.

error Command failed with exit code 2.
```
